### PR TITLE
feat: make credentials optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: '*'
+    branches: '**'
     tags-ignore: '*'
 
 jobs:

--- a/async-fetch.js
+++ b/async-fetch.js
@@ -1,17 +1,25 @@
 import { base64Encode, crocks, R } from "./deps.js";
 
 const { Async } = crocks;
-const { ifElse } = R;
+const { ifElse, assoc, pipe, identity } = R;
 
 // TODO: Tyler. wrap with opionated approach like before with https://github.com/vercel/fetch
 const asyncFetch = (fetch) => Async.fromPromise(fetch);
 
-const createHeaders = (username, password) => ({
-  "Content-Type": "application/json",
-  authorization: `Basic ${
-    base64Encode(new TextEncoder().encode(username + ":" + password))
-  }`,
-});
+const createHeaders = (username, password) =>
+  pipe(
+    assoc("Content-Type", "application/json"),
+    ifElse(
+      () => username && password,
+      assoc(
+        "authorization",
+        `Basic ${
+          base64Encode(new TextEncoder().encode(username + ":" + password))
+        }`,
+      ),
+      identity,
+    ),
+  )({});
 
 const handleResponse = (pred) =>
   ifElse(

--- a/mod.js
+++ b/mod.js
@@ -3,7 +3,7 @@ import { R } from "./deps.js";
 import { asyncFetch, createHeaders, handleResponse } from "./async-fetch.js";
 import adapter from "./adapter.js";
 
-const { mergeDeepRight, defaultTo, pipe } = R;
+const { mergeDeepLeft, defaultTo, pipe } = R;
 
 export default function ElasticsearchAdapter(config) {
   return Object.freeze({
@@ -11,7 +11,7 @@ export default function ElasticsearchAdapter(config) {
     port: "search",
     load: pipe(
       defaultTo({}),
-      mergeDeepRight(config),
+      mergeDeepLeft(config), // perfer config over what's passed from previous load
     ),
     link: (env) =>
       () => {


### PR DESCRIPTION
Elasticsearch can be used without providing credentials. Such is the case of Elasticsearch on AWS, if deployed in a VPC.

This PR makes it so that the authorization header is only added if username and password are provided to the adapter.